### PR TITLE
Fix playlist argument handling

### DIFF
--- a/generatePlaylist.py
+++ b/generatePlaylist.py
@@ -12,8 +12,8 @@ import config
 # Check if it is a backup file
 backup = False
 commercials = False
-if not len(sys.argv) > 1:
-    print ("Incorrect Usage: python3 generateShowList.py <backup? (yes | no)> <commercials? (yes | no)>")
+if len(sys.argv) < 3:
+    print ("Incorrect Usage: python3 generatePlaylist.py <backup? (yes | no)> <commercials? (yes | no)>")
     exit()
 else:
     if sys.argv[1] == "yes":


### PR DESCRIPTION
## Summary
- require at least two arguments
- fix usage message script name

## Testing
- `python3 -m py_compile generatePlaylist.py`
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_683fa86e3f008327a075ed842a39093c