### PR TITLE
Improve show name detection with relpath

### DIFF
--- a/generatePlaylist.py
+++ b/generatePlaylist.py
@@ -271,7 +271,7 @@ while len(showDirectory) > 0:
         randomEpisodeWrite = randomEpisode.encode('utf-8').strip().decode()
 
         # Get Name of Show
-        showName = randomEpisode.split(dir)[1].split('/')[0]
+        showName = os.path.relpath(randomEpisode, dir).split(os.sep)[0]
         showName = showName.encode('utf-8').strip().decode()
         
         # Get Description of Show (Episode Name)


### PR DESCRIPTION
## Summary
- improve path splitting logic for show name detection in `generatePlaylist.py`

## Testing
- `python3 -m py_compile generatePlaylist.py`
- `python3 -m py_compile generateXMLTV.py gui.py config.py setup_windows.py`

------
https://chatgpt.com/codex/tasks/task_e_683fa87b03088327b76b1390bb18e02f